### PR TITLE
fix: missing semicolon causing migration to fail

### DIFF
--- a/supabase/migrations/20230612070906_langchain.sql
+++ b/supabase/migrations/20230612070906_langchain.sql
@@ -16,7 +16,7 @@ alter table documents
 CREATE POLICY "Allow langchain querying for authenticated users" ON "public"."documents"
 AS PERMISSIVE FOR SELECT
 TO authenticated
-USING (true)
+USING (true);
 
 -- Create a function to search for documents
 create function match_documents (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...
Bug fix

## What is the current behavior?
`supabase db reset` fails due to missing semicolon in migration script

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
